### PR TITLE
Update client configuration script

### DIFF
--- a/bin/create-clients.sh
+++ b/bin/create-clients.sh
@@ -29,6 +29,7 @@ docker run --rm -it \
     --id reaction-next-starterkit \
     --secret CHANGEME \
     --grant-types authorization_code,refresh_token,client_credentials,implicit \
+    --token-endpoint-auth-method client_secret_post \
     --response-types token,code,id_token \
     --scope openid,offline \
     --callbacks http://localhost:4000/callback \


### PR DESCRIPTION
## Updates default port for callback

Tiny update to the port on the callback URL. 

Devs starting the Hydra app currently get a client with `3000` in the callback URL, but since our platform setup puts the storefront on 4000 as default, we should update this.

## Adds client_secret_post flag
[Doc ref](https://github.com/ory/hydra/blob/master/UPGRADE.md#oauth-20-clients-must-specify-correct-token_endpoint_auth_method)
> With support for the OpenID Connect Dynamic Discovery specification, a new field has been added to the OAuth 2.0 Client's
metadata which is `token_endpoint_auth_method`. The `token_endpoint_auth_method` specifies which authentication methods
the client can use at the token, introspection, and revocation endpoint.

> The default value for this method is `client_secret_basic` which uses the Basic HTTP Authorization scheme. If your client
uses the POST body to perform authentication, this value must be changed to `client_secret_post` 
