### PR TITLE
fix: wait for hydra then create the dev client

### DIFF
--- a/bin/create-clients.sh
+++ b/bin/create-clients.sh
@@ -12,25 +12,34 @@
 
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-docker_image=oryd/hydra:v1.0.0-beta.9-alpine
-network=auth.reaction.localhost
-hydra_admin_port=4445
-hydra_admin_url=http://hydra.${network}:${hydra_admin_port}
-
-# Logs a warning and fails silently for now. Hydra doesn't support updating
-# with this command.
-docker run --rm -it \
-  --network "${network}" \
-  --volume "${__dir}/wait-for-it.sh:/usr/local/bin/wait-for-it.sh" \
-  -e "HYDRA_ADMIN_URL=${hydra_admin_url}" \
-  --network "${network}" \
-  "${docker_image}" \
-  clients create --skip-tls-verify \
-    --id reaction-next-starterkit \
-    --secret CHANGEME \
-    --grant-types authorization_code,refresh_token,client_credentials,implicit \
-    --token-endpoint-auth-method client_secret_post \
-    --response-types token,code,id_token \
-    --scope openid,offline \
-    --callbacks http://localhost:4000/callback \
-  || echo "Failed to create OAuth2 client 'reaction-next-starterkit'"
+docker-compose run --rm \
+  --volume "${__dir}/wait-for.sh:/usr/local/bin/wait-for.sh" \
+  hydra-clients <<'EOF'
+set -e
+/usr/local/bin/wait-for.sh "${HYDRA_HOST}:${HYDRA_ADMIN_PORT}"
+# Want to check stderr on failure of the next command so +e
+set +e
+hydra clients create --skip-tls-verify \
+  --id reaction-next-starterkit \
+  --secret "${HYDRA_CLIENT_SECRET-CHANGEME}" \
+  --grant-types authorization_code,refresh_token,client_credentials,implicit \
+  --token-endpoint-auth-method client_secret_post \
+  --response-types token,code,id_token \
+  --scope openid,offline \
+  --callbacks http://localhost:4000/callback 2>/tmp/clients-create-stderr
+exit_code=$?
+case ${exit_code} in
+0)
+  echo SUCCESS: hydra client created
+  ;;
+*)
+  if grep 409 /tmp/clients-create-stderr >/dev/null; then
+    echo SUCCESS: hydra client already exists
+  else
+    echo ERROR: creating hydra client 1>&2
+    cat /tmp/clients-create-stderr 1>&2
+    exit ${exit_code}
+  fi
+  ;;
+esac
+EOF

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,21 @@ services:
       - DATABASE_URL=postgres://hydra:changeme@postgres:5432/hydra?sslmode=disable
     restart: on-failure
 
+  hydra-clients:
+    image: oryd/hydra:v1.0.0-beta.9-alpine
+    entrypoint: /bin/sh
+    depends_on:
+      - hydra
+    environment:
+      HYDRA_HOST: hydra.auth.reaction.localhost
+      HYDRA_ADMIN_PORT: 4445
+      HYDRA_ADMIN_URL: http://hydra.auth.reaction.localhost:4445
+      HYDRA_CLIENT_SECRET:
+    restart: never
+    networks:
+      default:
+      auth:
+
   hydra:
     image: oryd/hydra:v1.0.0-beta.9-alpine
     command: serve all --dangerous-force-http
@@ -60,6 +75,7 @@ services:
       - 5432
     volumes:
       - postgres-data:/var/lib/postgresql/data
+
 
 #  Uncomment the following section to use mysql instead.
 #  mysqld:


### PR DESCRIPTION
- Adds a new service to docker-compose.yml for this purpose
- Waits for hydra to be reachable via TCP
- runs the hydra clients create command
- Gracefully handles already-exist conflict
- Fails if anything else goes wrong
- Allows custom HYDRA_CLIENT_SECRET env var (optional)

fixes: #2