### PR TITLE
fix: Handle environment variables via env_file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+DATABASE_URL=postgres://hydra:changeme@postgres:5432/hydra?sslmode=disable
+OAUTH2_ACCESS_TOKEN_STRATEGY=jwt
+OAUTH2_CONSENT_URL=http://localhost:3000/consent
+OAUTH2_ISSUER_URL=http://localhost:4444
+OAUTH2_LOGIN_URL=http://localhost:3000/login
+OAUTH2_SHARE_ERROR_DEBUG=1
+OIDC_SUBJECT_TYPE_PAIRWISE_SALT=youReallyNeedToChangeThis
+OIDC_SUBJECT_TYPES_SUPPORTED=public,pairwise
+SYSTEM_SECRET=youReallyNeedToChangeThis

--- a/bin/setup
+++ b/bin/setup
@@ -1,30 +1,54 @@
 #!/usr/bin/env bash
 
+# Please Use Google Shell Style: https://google.github.io/styleguide/shell.xml
+
+# ---- Start unofficial bash strict mode boilerplate
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -o errexit  # always exit on error
+set -o errtrace # trap errors in functions as well
+set -o pipefail # don't ignore exit codes when piping output
+set -o posix    # more strict failures in subshells
+# set -x          # enable debugging
+
+IFS="$(printf "\n\t")"
+# ---- End unofficial bash strict mode boilerplate
+
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 env_file=${__dir}/../.env
-env_example_file=${__dir}/../.env.example
 
-function main {
+function main() {
   set -e
 
   add_new_env_vars
 }
 
-function add_new_env_vars {
+function add_new_env_vars() {
   # create .env and set perms if it does not exist
-  [ ! -f "${env_file}" ] && { touch "${env_file}" ; chmod 0600 "${env_file}" ; }
+  [[ ! -f "${env_file}" ]] && {
+    touch "${env_file}"
+    chmod 0600 "${env_file}"
+  }
 
-  export IFS=$'\n'
-  for var in $(cat "${env_example_file}"); do
-    key="${var%%=*}"     # get var key
-    var=$(eval echo "$var") # generate dynamic values
-
-    # If .env doesn't contain this env key, add it
-    if ! $(grep -qLE "^$key=" "${env_file}"); then
-      echo "Adding $key to .env"
-      echo "$var" >> "${env_file}"
-    fi
-  done
+  find . -name .env.example -type f -print0 |
+    (xargs -0 grep -Ehv '^\s*#' || true) |
+    sort |
+    {
+      while IFS= read -r var; do
+        if [[ -z "${var}" ]]; then
+          continue
+        fi
+        key="${var%%=*}" # get var key
+        # only eval for dynamic vars if the value has a dollar sign
+        if [[ "${var}" =~ "$" ]]; then
+          var="$(eval echo "${var}")" # generate dynamic values
+        fi
+        # If .env doesn't contain this env key, add it
+        if ! grep -qLE "^${key}=" "${env_file}"; then
+          echo "Adding $key to .env"
+          echo "$var" >>"${env_file}"
+        fi
+      done
+    }
 }
 
 main

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,9 +12,7 @@ services:
     command: migrate sql -e
     depends_on:
       - postgres
-    environment:
-#      - LOG_LEVEL=debug
-      - DATABASE_URL=postgres://hydra:changeme@postgres:5432/hydra?sslmode=disable
+    env_file: ".env"
     restart: on-failure
 
   hydra:
@@ -23,8 +21,6 @@ services:
     depends_on:
       - hydra-migrate
       - postgres
-#     Uncomment the following line to use mysql instead.
-#      - mysqld:mysqld
     networks:
       default:
       auth:
@@ -35,19 +31,7 @@ services:
       - "4445:4445"
       # Port for hydra token user
       - "5555:5555"
-    environment:
-#      - LOG_LEVEL=debug
-      - OAUTH2_ISSUER_URL=http://localhost:4444
-      - OAUTH2_CONSENT_URL=http://localhost:3000/consent
-      - OAUTH2_LOGIN_URL=http://localhost:3000/login
-      - DATABASE_URL=postgres://hydra:changeme@postgres:5432/hydra?sslmode=disable
-#     Uncomment the following line to use mysql instead.
-#      - DATABASE_URL=mysql://root:secret@tcp(mysqld:3306)/mysql?parseTime=true
-      - SYSTEM_SECRET=youReallyNeedToChangeThis
-      - OAUTH2_SHARE_ERROR_DEBUG=1
-      - OIDC_SUBJECT_TYPES_SUPPORTED=public,pairwise
-      - OIDC_SUBJECT_TYPE_PAIRWISE_SALT=youReallyNeedToChangeThis
-#     - OAUTH2_ACCESS_TOKEN_STRATEGY=jwt
+    env_file: ".env"
     restart: unless-stopped
 
   postgres:
@@ -60,13 +44,6 @@ services:
       - 5432
     volumes:
       - postgres-data:/var/lib/postgresql/data
-
-#  Uncomment the following section to use mysql instead.
-#  mysqld:
-#    image: mysql:5.7
-#    environment:
-#      - MYSQL_ROOT_PASSWORD=secret
-#
 
 volumes:
   postgres-data:


### PR DESCRIPTION
- Bring over better `bin/setup` script from reaction
- Move defaults from docker-compose.yml to .env.example


Impact: **minor**
Type: **bugfix**

## Issue

The only way to change the configuration of this project was by editing `docker-compose.yml` which leaves a git file locally modified. It's also not in convention with our other repos.

## Solution

- Use `env_file:` in docker-compose.yml and `.env` and `.env.example` files

Note I kept the actual values unchanged.

## Breaking changes

This is scripted via `bin/setup` as per our convention BUT existing developers are probably going to get an error if they try to start/restart hydra via docker-compose directly without running `bin/setup` or starting via reaction-platform Makefile.

Also if folks do have local modifications to `docker-compose.yml` they are likely to lose them if they `git checkout` that file to pull the latest code or just don't manually convert them to a `.env` file.
