### PR TITLE
Default OAuth access token strategy is opaque

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 DATABASE_URL=postgres://hydra:changeme@postgres:5432/hydra?sslmode=disable
-OAUTH2_ACCESS_TOKEN_STRATEGY=jwt
+OAUTH2_ACCESS_TOKEN_STRATEGY=opaque
 OAUTH2_CONSENT_URL=http://localhost:3000/consent
 OAUTH2_ISSUER_URL=http://localhost:4444
 OAUTH2_LOGIN_URL=http://localhost:3000/login


### PR DESCRIPTION
Resolves #16
Impact: **minor**
Type: **bugfix*

## Issue
Fixes the default `OAUTH2_ACCESS_TOKEN_STRATEGY` ENV.