### PR TITLE
release v2.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# v2.9.0
+# v2.8.1
 
-This is a minor update to keep this project in sync with [reaction v2.9.0](https://github.com/reactioncommerce/reaction), [example-storefront v2.9.0](https://github.com/reactioncommerce/example-storefront) and [reaction-platform v2.9.0](https://github.com/reactioncommerce/reaction-platform).
+This is a patch update to keep this project in sync with [reaction v2.8.1](https://github.com/reactioncommerce/reaction), [example-storefront v2.8.1](https://github.com/reactioncommerce/example-storefront) and [reaction-platform v2.8.1](https://github.com/reactioncommerce/reaction-platform).
 
 
 # v2.8.0


### PR DESCRIPTION
# v2.8.1

This is a patch update to keep this project in sync with [reaction v2.8.1](https://github.com/reactioncommerce/reaction), [example-storefront v2.8.1](https://github.com/reactioncommerce/example-storefront) and [reaction-platform v2.8.1](https://github.com/reactioncommerce/reaction-platform).