### PR TITLE
release v2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v2.9.0
+
+This is a minor update to keep this project in sync with [reaction v2.9.0](https://github.com/reactioncommerce/reaction), [example-storefront v2.9.0](https://github.com/reactioncommerce/example-storefront) and [reaction-platform v2.9.0](https://github.com/reactioncommerce/reaction-platform).
+
 # v2.8.1
 
 This is a patch update to keep this project in sync with [reaction v2.8.1](https://github.com/reactioncommerce/reaction), [example-storefront v2.8.1](https://github.com/reactioncommerce/example-storefront) and [reaction-platform v2.8.1](https://github.com/reactioncommerce/reaction-platform).


### PR DESCRIPTION
# v2.9.0

This is a minor update to keep this project in sync with [reaction v2.9.0](https://github.com/reactioncommerce/reaction), [example-storefront v2.9.0](https://github.com/reactioncommerce/example-storefront) and [reaction-platform v2.9.0](https://github.com/reactioncommerce/reaction-platform).