### PR TITLE
Revert "chore: Release v3.0.0"

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,9 @@
-DSN=postgres://hydra:changeme@postgres:5432/hydra?sslmode=disable
-OAUTH2_EXPOSE_INTERNAL_ERRORS=true
-OIDC_SUBJECT_IDENTIFIERS_ENABLED=true
-OIDC_SUBJECT_IDENTIFIERS_PAIRWISE_SALT=youReallyNeedToChangeThis
-SECRETS_SYSTEM=youReallyNeedToChangeThis
-URLS_CONSENT=http://localhost:4100/consent
-URLS_LOGIN=http://localhost:4100/login
-URLS_LOGOUT=http://localhost:4100/logout
-URLS_SELF_ISSUER=http://localhost:4444
+# OAUTH2_ACCESS_TOKEN_STRATEGY=opaque
+DATABASE_URL=postgres://hydra:changeme@postgres:5432/hydra?sslmode=disable
+OAUTH2_CONSENT_URL=http://localhost:3000/consent
+OAUTH2_ISSUER_URL=http://localhost:4444
+OAUTH2_LOGIN_URL=http://localhost:3000/login
+OAUTH2_SHARE_ERROR_DEBUG=1
+OIDC_SUBJECT_TYPE_PAIRWISE_SALT=youReallyNeedToChangeThis
+OIDC_SUBJECT_TYPES_SUPPORTED=public,pairwise
+SYSTEM_SECRET=youReallyNeedToChangeThis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,3 @@
-# v3.0.0-alpha
-
-This is a major update to keep this project in sync with [reaction
-v3.0.0-alpha](https://github.com/reactioncommerce/reaction), [example-storefront
-v3.0.0-alpha](https://github.com/reactioncommerce/example-storefront) and [reaction-platform v3.0.0-alpha](https://github.com/reactioncommerce/reaction-platform).
-
 # v2.9.0
 
 This is a minor update to keep this project in sync with [reaction v2.9.0](https://github.com/reactioncommerce/reaction), [example-storefront v2.9.0](https://github.com/reactioncommerce/example-storefront) and [reaction-platform v2.9.0](https://github.com/reactioncommerce/reaction-platform).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,15 +8,15 @@ networks:
 services:
 
   hydra-migrate:
-    image: oryd/hydra:v1.0.8
-    command: migrate sql -e -y
+    image: oryd/hydra:v1.0.0-beta.9-alpine
+    command: migrate sql -e
     depends_on:
       - postgres
     env_file: ".env"
     restart: on-failure
 
   hydra:
-    image: oryd/hydra:v1.0.8
+    image: oryd/hydra:v1.0.0-beta.9-alpine
     command: serve all --dangerous-force-http
     depends_on:
       - hydra-migrate


### PR DESCRIPTION
Reverts reactioncommerce/reaction-hydra#38

Reverting the merge of `release-3.0.0-alpha` into master. Master should stay on `2.x` until the official `3.0` release.