### PR TITLE
chore: update CHANGELOG for v2.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v2.9.1
+
+This is a patch update to keep this project in sync with [reaction v2.9.1](https://github.com/reactioncommerce/reaction), [example-storefront v2.9.1](https://github.com/reactioncommerce/example-storefront) and [reaction-platform v2.9.1](https://github.com/reactioncommerce/reaction-platform).
+
 # v2.9.0
 
 This is a minor update to keep this project in sync with [reaction v2.9.0](https://github.com/reactioncommerce/reaction), [example-storefront v2.9.0](https://github.com/reactioncommerce/example-storefront) and [reaction-platform v2.9.0](https://github.com/reactioncommerce/reaction-platform).


### PR DESCRIPTION
~[BLOCKED] Needs #40 merged first.~

# v2.9.1

This is a patch update to keep this project in sync with [reaction v2.9.1](https://github.com/reactioncommerce/reaction), [example-storefront v2.9.1](https://github.com/reactioncommerce/example-storefront) and [reaction-platform v2.9.1](https://github.com/reactioncommerce/reaction-platform).