### PR TITLE
feat: add URL for identity error page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ OIDC_SUBJECT_IDENTIFIERS_ENABLED=true
 OIDC_SUBJECT_IDENTIFIERS_PAIRWISE_SALT=youReallyNeedToChangeThis
 SECRETS_SYSTEM=youReallyNeedToChangeThis
 URLS_CONSENT=http://localhost:4100/consent
+URLS_ERROR=http://localhost:4100/account/oauth-error
 URLS_LOGIN=http://localhost:4100/login
 URLS_LOGOUT=http://localhost:4100/logout
 URLS_SELF_ISSUER=http://localhost:4444


### PR DESCRIPTION
Impact: **minor**
Type: **feature**

## Changes
Adds an example ENV to use a custom error page that now exists on Reaction Identity

## Testing
Test this with https://github.com/reactioncommerce/example-storefront/pull/637. All instructions are in that pull request.