### PR TITLE
release v3.0.0-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# v3.0.0-beta
+
+This is the beta release of the Reaction Hydra project that is designed to work with our new Reaction API.
+
+*Reaction releases will no longer be coordinated across all projects - we'll release each project, independently, as needed. This means version numbers will no longer be in sync. The newest versions of each project will work together. This change has two exceptions: we will release all projects in coordination for a `beta` release, and all projects in coordination for the official `v3.0.0` release.*
+
+## Features
+
+- feat: add URL for identity error page [#42](https://github.com/reactioncommerce/reaction-hydra/pull/42)
+
 # v3.0.0-alpha.2
 
 ## Features


### PR DESCRIPTION
# v3.0.0-beta

This is the beta release of the Reaction Hydra project that is designed to work with our new Reaction API.

*Reaction releases will no longer be coordinated across all projects - we'll release each project, independently, as needed. This means version numbers will no longer be in sync. The newest versions of each project will work together. This change has two exceptions: we will release all projects in coordination for a `beta` release, and all projects in coordination for the official `v3.0.0` release.*