### PR TITLE
chore: reconfigure docker-compose networks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-DSN=postgres://hydra:changeme@postgres:5432/hydra?sslmode=disable
+DSN=postgres://hydra:changeme@postgres.reaction.localhost:5432/hydra?sslmode=disable
 OAUTH2_EXPOSE_INTERNAL_ERRORS=true
 OIDC_SUBJECT_IDENTIFIERS_ENABLED=true
 OIDC_SUBJECT_IDENTIFIERS_PAIRWISE_SALT=youReallyNeedToChangeThis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
-version: '3'
+version: '3.4'
 
 networks:
-  auth:
+  reaction:
     external:
-      name: auth.reaction.localhost
+      name: reaction.localhost
 
 services:
 
@@ -23,7 +23,7 @@ services:
       - postgres
     networks:
       default:
-      auth:
+      reaction:
     ports:
       # Public port
       - "4444:4444"
@@ -40,6 +40,9 @@ services:
       - POSTGRES_USER=hydra
       - POSTGRES_PASSWORD=changeme
       - POSTGRES_DB=hydra
+    networks:
+      default:
+      reaction:
     ports:
       - 5432
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,9 @@ services:
     command: migrate sql -e -y
     depends_on:
       - postgres
+    networks:
+      default:
+      reaction:
     env_file: ".env"
     restart: on-failure
 


### PR DESCRIPTION
There are 5 related PRs that should be tested together:
https://github.com/reactioncommerce/example-storefront/pull/653
https://github.com/reactioncommerce/reaction-hydra/pull/46
https://github.com/reactioncommerce/reaction-admin/pull/194
https://github.com/reactioncommerce/reaction-identity/pull/23
https://github.com/reactioncommerce/reaction/pull/6068

All of these ensure that docker-compose defines exactly one external network named `reaction.localhost` and update all services and ENV to use that one. This is being done to cut down on confusion caused by having various arbitrary networks. This affects only local development using docker-compose.

The only downside we're aware of is that project authors need to be more careful about giving Reaction services unique names (e.g., can't call them all `web`).

One upside in addition to being generally less confusing is that the primary internal hostname for the API is now just `api.reaction.localhost` rather than the more confusing `api.api.reaction.localhost`.

## Testing
1. Switch to the PR branches of all 5 projects linked above.
2. Copy `.env.example` to `.env` in each project, completely replacing `.env`.
3. Stop all Docker containers.
4. `docker system prune`
5. Delete the `docker-compose.override.yml` file from each of the project directories. It doesn't technically matter whether you leave the override in place, but everything will start faster if you don't.
6. In the platform directory, `make start`.
7. Once all services are running, check all service logs for errors, and do some basic smoke tests such as logging in to both admin and storefront.